### PR TITLE
Fixed several minor bugs & replaced build script with a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+
+ifndef NDEBUG
+CFLAGS = -g
+else
+CFLAGS = -O2
+endif
+
+headers = ops.h domains.h ops_names.h domains_names.h
+
+all: mq_listener io_monitor.so
+
+ops_names.h: ops.h
+	cat ops.h | ./enum_to_strings.sh ops_names >ops_names.h
+
+domains_names.h: domains.h
+	cat domains.h | ./enum_to_strings.sh domains_names >domains_names.h
+
+io_monitor.so: io_monitor.c $(headers)
+	gcc $(CFLAGS) -shared -fPIC io_monitor.c -o io_monitor.so -ldl
+
+
+mq_listener: mq_listener.c $(headers)
+	gcc $(CFLAGS) mq_listener.c -o mq_listener
+
+clean:
+	rm -f mq_listener
+	rm -f io_monitor.so
+	rm -f domains_names.h
+	rm -f ops_names.h

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-cat ops.h | ./enum_to_strings.sh ops_names >ops_names.h
-cat domains.h | ./enum_to_strings.sh domains_names >domains_names.h
-
-gcc -shared -fPIC io_monitor.c -o io_monitor.so -ldl
-gcc mq_listener.c -o mq_listener

--- a/io_monitor.c
+++ b/io_monitor.c
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <utime.h>
+#include <time.h>
 #include <errno.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -51,6 +52,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <arpa/inet.h>
 #include "ops.h"
 #include "domains.h"
 
@@ -2269,7 +2271,7 @@ int fallocate(int fd, int mode, off_t offset, off_t len)
    PUTS("ftruncate")
    DECL_VARS()
    GET_START_TIME()
-   const int rc = orig_allocate(fd, mode, offset, len);
+   const int rc = orig_fallocate(fd, mode, offset, len);
    GET_END_TIME()
    ssize_t bytes_written;
 


### PR DESCRIPTION
Following changes in this patch:
- Added missing headers, so that program now builds without compiler warnings
- replaced call to nonexistent function orig_allocate for orig_fallocate
- Added Makefile (hope, it's not against your design)

Signed-off-by: maciej <maciej.a.kaminski@gmail.com>